### PR TITLE
Add `.scala-steward.conf`

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]


### PR DESCRIPTION
sbt plugins are pinned to Scala 2.12